### PR TITLE
Add Windows on Arm support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
           -B ${{github.workspace}}/build
           -H.
           -GNinja
-          -DDYNARMIC_USE_BUNDLED_CATCH=ON
+          -DOAKNUT_USE_BUNDLED_CATCH=ON
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,5 +54,33 @@ if (MASTER_PROJECT)
     )
     target_include_directories(oaknut-tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
     target_link_libraries(oaknut-tests PRIVATE Catch2::Catch2WithMain merry::oaknut)
-    target_compile_options(oaknut-tests PRIVATE -Wall -Wextra -Wcast-qual -pedantic -pedantic-errors -Wfatal-errors -Wno-missing-braces)
+    if (MSVC)
+        target_compile_options(oaknut-tests PRIVATE
+            /experimental:external
+            /external:W0
+            /external:anglebrackets
+            /W4
+            /w44263 # Non-virtual member function hides base class virtual function
+            /w44265 # Class has virtual functions, but destructor is not virtual
+            /w44456 # Declaration of 'var' hides previous local declaration
+            /w44457 # Declaration of 'var' hides function parameter
+            /w44458 # Declaration of 'var' hides class member
+            /w44459 # Declaration of 'var' hides global definition
+            /w44946 # Reinterpret-cast between related types
+            /wd4592 # Symbol will be dynamically initialized (implementation limitation)
+            /permissive- # Stricter C++ standards conformance
+            /MP
+            /Zi
+            /Zo
+            /EHsc
+            /Zc:externConstexpr # Allows external linkage for variables declared "extern constexpr", as the standard permits.
+            /Zc:inline          # Omits inline functions from object-file output.
+            /Zc:throwingNew     # Assumes new (without std::nothrow) never returns null.
+            /volatile:iso       # Use strict standard-abiding volatile semantics
+            /bigobj             # Increase number of sections in .obj files
+            /DNOMINMAX
+        )
+    else()
+        target_compile_options(oaknut-tests PRIVATE -Wall -Wextra -Wcast-qual -pedantic -pedantic-errors -Wfatal-errors -Wno-missing-braces)
+    endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ target_compile_features(oaknut INTERFACE cxx_std_20)
 
 # Tests
 if (MASTER_PROJECT)
-    if (DYNARMIC_USE_BUNDLED_CATCH)
+    option(OAKNUT_USE_BUNDLED_CATCH "Use the embedded Catch2 submodule" OFF)
+    if (OAKNUT_USE_BUNDLED_CATCH)
         add_subdirectory(externals/catch)
     else()
         find_package(Catch2 3 REQUIRED)

--- a/include/oaknut/code_block.hpp
+++ b/include/oaknut/code_block.hpp
@@ -9,6 +9,7 @@
 #include <new>
 
 #if defined(_WIN32)
+#    define NOMINMAX
 #    include <windows.h>
 #elif defined(__APPLE__)
 #    include <libkern/OSCacheControl.h>
@@ -78,6 +79,8 @@ public:
     {
 #if defined(__APPLE__)
         sys_icache_invalidate(mem, size);
+#elif defined(_WIN32)
+        FlushInstructionCache(GetCurrentProcess(), mem, size);
 #else
         static std::size_t icache_line_size = 0x10000, dcache_line_size = 0x10000;
 


### PR DESCRIPTION
Some fixes that get Oaknut working on an ARM-based Windows machine.
Passes all unit-tests on my ThinkPad x13s.