### PR TITLE
oaknut: CI: Add msvc-arm64 build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,3 +42,34 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         run: qemu-aarch64 -L /usr/aarch64-linux-gnu ./oaknut-tests -d yes
+        
+  test_on_windows:
+    runs-on: windows-latest
+    name: msvc-arm64
+
+    steps:
+      - name: Checkout oaknut repo
+        uses: actions/checkout@v3
+
+      - name: Checkout Catch2 v3 repo
+        uses: actions/checkout@v3
+        with:
+          repository: catchorg/Catch2
+          ref: v3.2.0
+          path: externals/catch
+      
+      - name: Setup msvc-arm64 environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_arm64
+
+      - name: Configure CMake
+        run: >
+          cmake
+          -B ${{github.workspace}}/build
+          -GNinja
+          -DOAKNUT_USE_BUNDLED_CATCH=ON
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: cmake --build . --config Release


### PR DESCRIPTION
Adds msvc-arm64 cross-compilation to the CI. Doesn't run the unit-tests since there is no qemu-user for Windows but should be enough to verify a successful Windows on Arm build moving forward.