### PR TITLE
oaknut: Add support for iOS memory protection.

### DIFF
--- a/include/oaknut/code_block.hpp
+++ b/include/oaknut/code_block.hpp
@@ -16,6 +16,7 @@
 #    include <pthread.h>
 #    include <sys/mman.h>
 #    include <unistd.h>
+#    include <TargetConditionals.h>
 #else
 #    include <sys/mman.h>
 #endif
@@ -30,7 +31,11 @@ public:
 #if defined(_WIN32)
         m_memory = (std::uint32_t*)VirtualAlloc(nullptr, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
 #elif defined(__APPLE__)
+    #if TARGET_OS_IPHONE
+        m_memory = (std::uint32_t*)mmap(nullptr, size, PROT_READ | PROT_EXEC, MAP_ANON | MAP_PRIVATE, -1, 0);
+    #else
         m_memory = (std::uint32_t*)mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE | MAP_JIT, -1, 0);
+    #endif
 #else
         m_memory = (std::uint32_t*)mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE, -1, 0);
 #endif
@@ -64,14 +69,22 @@ public:
     void protect()
     {
 #if defined(__APPLE__)
+    #if TARGET_OS_IPHONE
+        mprotect(m_memory, m_size, PROT_READ | PROT_EXEC);
+    #else
         pthread_jit_write_protect_np(1);
+    #endif
 #endif
     }
 
     void unprotect()
     {
 #if defined(__APPLE__)
+    #if TARGET_OS_IPHONE
+        mprotect(m_memory, m_size, PROT_READ | PROT_WRITE);
+    #else
         pthread_jit_write_protect_np(0);
+    #endif
 #endif
     }
 


### PR DESCRIPTION
Adds specialized case of \_\_APPLE\_\_ memory protection for iOS, where ```pthread_jit_write_protect_np``` does not exist. Instead we need to use ```mprotect``` to switch between RX and RW.