### PR TITLE
oaknut: Add `ptr` accessor to `Label`

### DIFF
--- a/include/oaknut/oaknut.hpp
+++ b/include/oaknut/oaknut.hpp
@@ -53,6 +53,18 @@ struct Label {
 public:
     Label() = default;
 
+    bool is_bound() const
+    {
+        return m_addr.has_value();
+    }
+
+    template<typename T>
+    T ptr() const
+    {
+        static_assert(std::is_pointer_v<T> || std::is_same_v<T, std::uintptr_t> || std::is_same_v<T, std::intptr_t>);
+        return reinterpret_cast<T>(m_addr.value());
+    }
+
 private:
     template<typename Policy>
     friend class BasicCodeGenerator;


### PR DESCRIPTION
Accesses the underlying `m_addr` for a `Label`. Allows client code to derive the actual memory location of a `Label`.

`m_addr` is an `std::optional` so I'm not sure what to return in the case that the `Label` does not have a value yet. So I'm using [std::optional::value()](https://en.cppreference.com/w/cpp/utility/optional/value) and letting it throw [std::bad_optional_access](https://en.cppreference.com/w/cpp/utility/optional/bad_optional_access) in the case that there is no value yet.