### PR TITLE
oaknut: Add `const` qualifier to `AddrOffset` ctor

### DIFF
--- a/include/oaknut/impl/offset.hpp
+++ b/include/oaknut/impl/offset.hpp
@@ -45,7 +45,7 @@ struct AddrOffset {
         : m_payload(&label)
     {}
 
-    AddrOffset(void* ptr)
+    AddrOffset(const void* ptr)
         : m_payload(ptr)
     {}
 
@@ -63,7 +63,7 @@ struct AddrOffset {
 private:
     template<typename Policy>
     friend class BasicCodeGenerator;
-    std::variant<std::uint32_t, Label*, void*> m_payload;
+    std::variant<std::uint32_t, Label*, const void*> m_payload;
 };
 
 template<std::size_t bitsize, std::size_t shift_amount>

--- a/include/oaknut/oaknut.hpp
+++ b/include/oaknut/oaknut.hpp
@@ -249,7 +249,7 @@ private:
                                   label->m_wbs.emplace_back(Label::Writeback{Policy::current_address(), ~splat, static_cast<Label::EmitFunctionType>(encode_fn)});
                                   return 0u;
                               },
-                              [&](void* p) {
+                              [&](const void* p) {
                                   return encode_fn(Policy::current_address(), reinterpret_cast<std::uintptr_t>(p));
                               },
                           },


### PR DESCRIPTION
Can't seem to tell if this is intentionally non-const, or not, but this fixes some function-pointer issues I was facing on MacOS.