### PR TITLE
oaknut: Fix clang-format errors

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,6 @@
 Language:        Cpp
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
@@ -175,7 +174,6 @@ SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
-SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
@@ -189,7 +187,6 @@ SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
 SpacesInAngles:  false
-SpacesInConditionalStatement: false
 SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false


### PR DESCRIPTION
Fixes some duplicate mapping key errors that occur when trying to run
clang-format.

```
.../oaknut/.clang-format:9:1: error: duplicated mapping key 'AlignConsecutiveMacros'
AlignConsecutiveMacros: None
^~~~~~~~~~~~~~~~~~~~~~
Error reading .../oaknut/.clang-format: Invalid argument
```